### PR TITLE
Deprecation fixes and code update with formatting

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,0 +1,3 @@
+[
+  inputs: ["mix.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/README.md
+++ b/README.md
@@ -12,3 +12,14 @@ defmodule MyPlug do
   plug PlugForwardedPeer
 end
 ```
+## With Phoenix
+
+```elixir
+defmodule MyAppWeb.Endpoint do
+
+  # ... lots of code
+
+  plug PlugForwardedPeer # <- Insert before Router to have it cover all pipelines
+  plug MyAppWeb.Router
+end
+```

--- a/lib/plug_forwarded_peer.ex
+++ b/lib/plug_forwarded_peer.ex
@@ -1,31 +1,52 @@
 defmodule PlugForwardedPeer do
   import Plug.Conn
+
   def init(_), do: []
-  def call(conn,_) do
-    case get_req_header(conn,"x-forwarded-for") do
-      []->
-        case get_req_header(conn,"forwarded") do
-          []-> conn
-          [header|_]->
-            ips = for "for="<>quoted_ip<-String.split(header,~r/\s*,\s*/), ip=clean_ip(quoted_ip), !is_nil(ip), do: ip
-            case ips do
-              []->conn
-              [ip|_]->%{conn|remote_ip: ip}
-            end
-        end
-      [header|_]->
-        ips = for quoted_ip<-String.split(header,~r/\s*,\s*/), ip=clean_ip(quoted_ip), !is_nil(ip), do: ip
-        case ips do
-          []->conn
-          [ip|_]->%{conn|remote_ip: ip}
-        end
+
+  def call(conn, _) do
+    cond do
+      header_data = extract_data_from_header(conn, "x-forwarded-for") ->
+        extract_and_replace_remote_ip(conn, header_data)
+
+      header_data = extract_data_from_header(conn, "forwarded") ->
+        extract_and_replace_remote_ip(conn, header_data)
+
+      true ->
+        conn
     end
   end
-  def clean_ip(maybe_quoted_ip) do
-    maybe_ip = maybe_quoted_ip |> String.strip(?") |> String.rstrip(?]) |> String.lstrip(?[)
+
+  defp clean_ip(maybe_quoted_ip) do
+    maybe_ip =
+      maybe_quoted_ip
+      |> String.trim(~s(for=))
+      |> String.trim(~s("))
+      |> String.trim_trailing("]")
+      |> String.trim_leading("[")
+
     case :inet_parse.address('#{maybe_ip}') do
-      {:ok,ip}->ip
-      _->nil
+      {:ok, ip} -> ip
+      _ -> nil
+    end
+  end
+
+  defp extract_data_from_header(conn, header_name) do
+    case get_req_header(conn, header_name) do
+      [] -> nil
+      [head | _tail] -> head
+    end
+  end
+
+  defp extract_and_replace_remote_ip(conn, data) do
+    ips =
+      data
+      |> String.split(~r/\s*,\s*/)
+      |> Enum.map(&clean_ip/1)
+      |> Enum.reject(&is_nil/1)
+
+    case ips do
+      [] -> conn
+      [ip | _] -> %{conn | remote_ip: ip}
     end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -23,6 +23,6 @@ defmodule PlugForwardedPeer.Mixfile do
   end
 
   defp deps do
-   [{:plug, ">= 0.13.0 and < 2.0.0"}]
+   [{:plug, ">= 1.0.0 and < 2.0.0"}]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -15,7 +15,7 @@ defmodule PlugForwardedPeer.Mixfile do
                contributors: ["Arnaud Wetzel"],
                licenses: ["MIT"],
                files: ["lib", "priv", "mix.exs", "README*", "templates", "LICENSE*"]],
-     deps: deps]
+     deps: deps()]
   end
 
   def application do

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule PlugForwardedPeer.Mixfile do
 
   def project do
     [app: :plug_forwarded_peer,
-     version: "0.0.2",
+     version: "0.0.3",
      elixir: "~> 1.0",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
@@ -12,7 +12,7 @@ defmodule PlugForwardedPeer.Mixfile do
      to rfc7239 and fill `conn.remote_ip` with the root client ip.
      """,
      package: [links: %{"Source"=>"http://github.com/awetzel/plug_forwarded_peer"},
-               contributors: ["Arnaud Wetzel"],
+               contributors: ["Arnaud Wetzel", "Kiere El-Shafie"],
                licenses: ["MIT"],
                files: ["lib", "priv", "mix.exs", "README*", "templates", "LICENSE*"]],
      deps: deps()]

--- a/mix.lock
+++ b/mix.lock
@@ -1,1 +1,5 @@
-%{"plug": {:hex, :plug, "0.13.0"}}
+%{
+  "mime": {:hex, :mime, "1.3.1", "30ce04ab3175b6ad0bdce0035cba77bba68b813d523d1aac73d9781b4d193cf8", [:mix], [], "hexpm"},
+  "plug": {:hex, :plug, "1.7.1", "8516d565fb84a6a8b2ca722e74e2cd25ca0fc9d64f364ec9dbec09d33eb78ccd", [:mix], [{:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}, {:plug_crypto, "~> 1.0", [hex: :plug_crypto, repo: "hexpm", optional: false]}], "hexpm"},
+  "plug_crypto": {:hex, :plug_crypto, "1.0.0", "18e49317d3fa343f24620ed22795ec29d4a5e602d52d1513ccea0b07d8ea7d4d", [:mix], [], "hexpm"},
+}

--- a/test/plug_forwarded_peer_test.exs
+++ b/test/plug_forwarded_peer_test.exs
@@ -2,28 +2,29 @@ defmodule PlugForwardedPeerTest do
   use ExUnit.Case
   use Plug.Test
 
-  defp test_conn(header \\ nil,value \\ nil) do 
-    c = %{conn("GET","/")| remote_ip: {127,0,0,1}}
-    c = if header, do: put_req_header(c,header,value), else: c
-    PlugForwardedPeer.call(c,[]).remote_ip
+  defp test_conn(header \\ nil, value \\ nil) do
+    c = %{conn("GET", "/") | remote_ip: {127, 0, 0, 1}}
+    c = if header, do: put_req_header(c, header, value), else: c
+    PlugForwardedPeer.call(c, []).remote_ip
   end
 
   test "no header keeps peer ip" do
-    assert test_conn == {127,0,0,1}
+    assert test_conn() == {127, 0, 0, 1}
   end
 
   test "override client-ip with x-forwarded-for" do
-    assert test_conn("x-forwarded-for","200.10.0.1 , 100.1.29.1, 12") == {200,10,0,1}
-    assert test_conn("x-forwarded-for",~s/"200.10.0.1" , 100.1.29.1, 12/) == {200,10,0,1}
-    assert test_conn("x-forwarded-for",~s/"titi" , [::1], 12/) == {0,0,0,0,0,0,0,1}
+    assert test_conn("x-forwarded-for", "200.10.0.1 , 100.1.29.1, 12") == {200, 10, 0, 1}
+    assert test_conn("x-forwarded-for", ~s/"200.10.0.1" , 100.1.29.1, 12/) == {200, 10, 0, 1}
+    assert test_conn("x-forwarded-for", ~s/"titi" , [::1], 12/) == {0, 0, 0, 0, 0, 0, 0, 1}
   end
 
   test "override client-ip with forwarded for:" do
-    assert test_conn("forwarded",~s/host=toto, for="[::1]", for="127.1.1.1"/) == {0,0,0,0,0,0,0,1}
+    assert test_conn("forwarded", ~s/host=toto, for="[::1]", for="127.1.1.1"/) ==
+             {0, 0, 0, 0, 0, 0, 0, 1}
   end
-  
+
   test "override client-ip with wrong ip keeps peer ip" do
-    assert test_conn("x-forwarded-for","errornous header") == {127,0,0,1}
-    assert test_conn("forwarded",~s/host=toto, for="[:1]", for="256.1.1.1"/) == {127,0,0,1}
+    assert test_conn("x-forwarded-for", "errornous header") == {127, 0, 0, 1}
+    assert test_conn("forwarded", ~s/host=toto, for="[:1]", for="256.1.1.1"/) == {127, 0, 0, 1}
   end
 end


### PR DESCRIPTION
- Fixed deprecation warnings when used with new Phoenix project (1.4.0) and Elixir 1.8.1 (on Erlang 21.1.4)
- Bumped Plug to minimum of v1.0.0 or greater
- Extracted duplicate code to functions
- Updated code to make more use of pipeline transformations of data
- Ran Elixir Formatter on code